### PR TITLE
SLM-12 - add an email client to send magic link URLs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  implementation("org.springframework.boot:spring-boot-starter-mail")
 
   implementation("org.springdoc:springdoc-openapi-ui:1.5.12")
   implementation("org.springdoc:springdoc-openapi-data-rest:1.5.12")

--- a/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
@@ -31,6 +31,8 @@ generic-service:
   namespace_secrets:
     send-legal-mail-to-prisons-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+      SPRING_MAIL_USERNAME: "EMAIL_USERNAME"
+      SPRING_MAIL_PASSWORD: "EMAIL_PASSWORD"
     rds-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    APP_MAGICLINK_URL: https://send-legal-mail-dev.hmpps.service.justice.gov.uk/link/verify-link
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,6 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    APP_MAGICLINK_URL: https://send-legal-mail-preprod.hmpps.service.justice.gov.uk/link/verify-link
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/MagicLinkConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/MagicLinkConfig.kt
@@ -6,4 +6,7 @@ import java.time.Duration
 
 @ConstructorBinding
 @ConfigurationProperties(prefix = "app.magiclink")
-data class MagicLinkConfig(val secretExpiry: Duration)
+data class MagicLinkConfig(
+  val secretExpiry: Duration,
+  val url: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSender.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink
+
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.MagicLinkConfig
+
+class MagicLinkEmailSender(
+  private val magicLinkConfig: MagicLinkConfig,
+  private val javaMailSender: JavaMailSender,
+) {
+
+  fun send(email: String, secret: String) {
+    SimpleMailMessage().apply {
+      setTo(email)
+      subject = "Send Legal Mail Sign in"
+      text = "${magicLinkConfig.url}?secret=$secret"
+    }
+      .also { javaMailSender.send(it) }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,15 @@ spring:
         jwt:
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: fakeUsername
+    password: fakePassword
+    properties.mail.smtp:
+      auth: true
+      starttls.enable: true
+
 server:
   port: 8080
   servlet:
@@ -77,3 +86,4 @@ management:
 app:
   magiclink:
     secret-expiry: 10m
+    url: "http://localhost:3000/link/verify-link"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSenderTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -18,29 +17,12 @@ class MagicLinkEmailSenderTest {
   private val magicLinkEmailSender = MagicLinkEmailSender(MagicLinkConfig(Duration.of(0, ChronoUnit.SECONDS), "some-url"), mockMailSender)
 
   @Test
-  fun `The mail sender should be called to send the mail`() {
-    magicLinkEmailSender.send("any-email", "any-secret")
-
-    verify(mockMailSender).send(any<SimpleMailMessage>())
-  }
-
-  @Test
-  fun `The mail should be sent to the passed email`() {
-    magicLinkEmailSender.send("an.email@company.com", "any-secret")
+  fun `The mail should be sent to the user with a magic link`() {
+    magicLinkEmailSender.send("an.email@company.com", "this-is-a-secret")
 
     verify(mockMailSender).send(
       check<SimpleMailMessage> {
         assertThat(it.to).isEqualTo(arrayOf("an.email@company.com"))
-      }
-    )
-  }
-
-  @Test
-  fun `The mail should contain the magic link`() {
-    magicLinkEmailSender.send("any-email", "this-is-a-secret")
-
-    verify(mockMailSender).send(
-      check<SimpleMailMessage> {
         assertThat(it.text).contains("some-url?secret=this-is-a-secret")
       }
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSenderTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.MagicLinkConfig
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+class MagicLinkEmailSenderTest {
+
+  private val mockMailSender: JavaMailSender = mock()
+  private val magicLinkEmailSender = MagicLinkEmailSender(MagicLinkConfig(Duration.of(0, ChronoUnit.SECONDS), "some-url"), mockMailSender)
+
+  @Test
+  fun `The mail sender should be called to send the mail`() {
+    magicLinkEmailSender.send("any-email", "any-secret")
+
+    verify(mockMailSender).send(any<SimpleMailMessage>())
+  }
+
+  @Test
+  fun `The mail should be sent to the passed email`() {
+    magicLinkEmailSender.send("an.email@company.com", "any-secret")
+
+    verify(mockMailSender).send(
+      check<SimpleMailMessage> {
+        assertThat(it.to).isEqualTo(arrayOf("an.email@company.com"))
+      }
+    )
+  }
+
+  @Test
+  fun `The mail should contain the magic link`() {
+    magicLinkEmailSender.send("any-email", "this-is-a-secret")
+
+    verify(mockMailSender).send(
+      check<SimpleMailMessage> {
+        assertThat(it.text).contains("some-url?secret=this-is-a-secret")
+      }
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,6 +6,7 @@ management:
     health.cache.time-to-live: 0
     info.cache.time-to-live: 0
   health.redis.enabled: false
+  health.mail.enabled: false
 
 spring:
   jpa:


### PR DESCRIPTION
* the email client is not being used yet - integration tests coming once it is wired up
* Kube secrets added to dev and preprod (we don't have a prod yet)