### PR TITLE
SLM-12 - accept JWTs created when verifying a magic link

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
@@ -53,6 +54,6 @@ class BarcodeResource(private val barcodeService: BarcodeService) {
       )
     ]
   )
-  fun createBarcode(@AuthenticationPrincipal userId: String): String =
-    barcodeService.createBarcode(userId)
+  fun createBarcode(@AuthenticationPrincipal userDetails: UserDetails): String =
+    barcodeService.createBarcode(userDetails.username)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/CreateBarcodeUserDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/CreateBarcodeUserDetailsService.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Component
+
+@Component
+class CreateBarcodeUserDetailsService(private val jwtService: JwtService) :
+  UserDetailsService {
+  override fun loadUserByUsername(token: String): UserDetails =
+    token
+      .takeIf { jwtService.validateToken(it) }
+      ?.let { jwtService.subject(it) }
+      ?.takeIf { username -> username.isNotBlank() }
+      ?.let { username -> User(username, "n/a", mutableListOf(SimpleGrantedAuthority("ROLE_SLM_CREATE_BARCODE"))) }
+      ?: throw UsernameNotFoundException("Token $token is invalid")
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/IntegrationTest.kt
@@ -74,6 +74,9 @@ abstract class IntegrationTest {
     scopes: List<String> = listOf()
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes)
 
+  internal fun setCreateBarcodeAuthorisation(email: String = "some.user@company.com.cjsm.net"): (HttpHeaders) -> Unit =
+    jwtAuthHelper.setCreateBarcodeAuthorisation(email)
+
   @TestConfiguration
   class RedisConfig {
     private val redisServer: RedisServer = RedisServer(6380)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/JwtAuthHelper.kt
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security.JwtService
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPublicKey
@@ -15,7 +16,7 @@ import java.util.Date
 import java.util.UUID
 
 @Component
-class JwtAuthHelper {
+class JwtAuthHelper(private val jwtService: JwtService) {
   private val keyPair: KeyPair
 
   init {
@@ -39,6 +40,11 @@ class JwtAuthHelper {
       roles = roles
     )
     return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
+  }
+
+  fun setCreateBarcodeAuthorisation(email: String = "some.user@company.com.cjsm.net"): (HttpHeaders) -> Unit {
+    val token = jwtService.generateToken(email)
+    return { it.set("Create-Barcode-Token", token) }
   }
 
   internal fun createJwt(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/barcode/BarcodeResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/barcode/BarcodeResourceTest.kt
@@ -43,7 +43,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_CREATE_BARCODE")))
+        .headers(setCreateBarcodeAuthorisation())
         .exchange()
         .expectStatus().isCreated
         .expectBody()
@@ -52,7 +52,7 @@ class BarcodeResourceTest : IntegrationTest() {
       val savedBarcode = barcodeRepository.findById("SOME_CODE").orElseThrow()
       val savedBarcodeEvents = barcodeEventRepository.findByBarcode(savedBarcode)
       assertThat(savedBarcodeEvents).extracting<String> { it.barcode.code }.containsExactly("SOME_CODE")
-      assertThat(savedBarcodeEvents).extracting<String>(BarcodeEvent::userId).containsExactly("some.user@domain.com")
+      assertThat(savedBarcodeEvents).extracting<String>(BarcodeEvent::userId).containsExactly("some.user@company.com.cjsm.net")
       assertThat(savedBarcodeEvents).extracting<BarcodeStatus>(BarcodeEvent::status)
         .containsExactly(BarcodeStatus.CREATED)
     }
@@ -68,7 +68,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_CREATE_BARCODE")))
+        .headers(setCreateBarcodeAuthorisation())
         .exchange()
         .expectStatus().isCreated
         .expectBody()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/CreateBarcodeUserDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/CreateBarcodeUserDetailsServiceTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+
+class CreateBarcodeUserDetailsServiceTest {
+
+  private val jwtService: JwtService = mock()
+  private val createBarcodeUserDetailsService = CreateBarcodeUserDetailsService(jwtService)
+
+  @Test
+  fun `should create user details for valid token`() {
+    whenever(jwtService.validateToken(anyString())).thenReturn(true)
+    whenever(jwtService.subject(anyString())).thenReturn("some.user@company.com.cjsm.net")
+
+    val userDetails = createBarcodeUserDetailsService.loadUserByUsername("some-token")
+
+    assertThat(userDetails.username).isEqualTo("some.user@company.com.cjsm.net")
+    assertThat(userDetails.authorities).containsExactly(SimpleGrantedAuthority("ROLE_SLM_CREATE_BARCODE"))
+    verify(jwtService).validateToken("some-token")
+    verify(jwtService).subject("some-token")
+  }
+
+  @Test
+  fun `should throw for invalid token`() {
+    whenever(jwtService.validateToken(anyString())).thenReturn(false)
+
+    assertThatThrownBy { createBarcodeUserDetailsService.loadUserByUsername("some-token") }
+      .isInstanceOf(UsernameNotFoundException::class.java)
+      .hasMessageContaining("some-token")
+
+    verify(jwtService).validateToken("some-token")
+    verifyNoMoreInteractions(jwtService)
+  }
+
+  @Test
+  fun `should throw if there is no username`() {
+    whenever(jwtService.validateToken(anyString())).thenReturn(true)
+    whenever(jwtService.subject(anyString())).thenReturn("")
+
+    assertThatThrownBy { createBarcodeUserDetailsService.loadUserByUsername("some-token") }
+      .isInstanceOf(UsernameNotFoundException::class.java)
+      .hasMessageContaining("some-token")
+
+    verify(jwtService).validateToken("some-token")
+    verify(jwtService).subject("some-token")
+  }
+}


### PR DESCRIPTION
We now accept a `PreAuthenticatedAuthenticationToken` on header `Create-Barcode-Token`. If the token is valid - it was signed by this service and has not expired - then the token is accepted as authentication. 