### PR TITLE
SLM-11 - Apply max email length of 254 characters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/SendLegalMailToPrisonsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/SendLegalMailToPrisonsApiExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestClientResponseException
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MAX_EMAIL_LENGTH
 import javax.persistence.EntityNotFoundException
 
 private val log = KotlinLogging.logger {}
@@ -95,6 +96,7 @@ enum class ErrorCode(val userMessage: String) {
   NOT_FOUND("Not found"),
   // Custom errors
   EMAIL_MANDATORY("The email address must be entered"),
+  EMAIL_TOO_LONG("The email address can have a maximum length of $MAX_EMAIL_LENGTH"),
   INVALID_EMAIL("Enter an email address in the correct format"),
   INVALID_CJSM_EMAIL("Enter an email address which ends with 'cjsm.net'"),
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/E2eTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/E2eTest.kt
@@ -9,7 +9,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.integration.magiclink.Message
-import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MagicLinkResource
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.VerifyLinkResponse
 
 class E2eTest(
   @Value("\${mailcatcher.api.port}") private val mailcatcherApiPort: Int,
@@ -66,7 +66,7 @@ class E2eTest(
       .body(BodyInserters.fromValue("""{ "secret": "$secretValue" }"""))
       .exchange()
       .expectStatus().isCreated
-      .returnResult(MagicLinkResource.VerifyLinkResponse::class.java)
+      .returnResult(VerifyLinkResponse::class.java)
       .responseBody
       .blockFirst()
       ?.token

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/magiclink/MagicLinkResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/integration/magiclink/MagicLinkResourceTest.kt
@@ -11,8 +11,8 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.ErrorCode
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.integration.IntegrationTest
-import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MagicLinkResource
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MagicLinkSecret
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.VerifyLinkResponse
 
 class MagicLinkResourceTest(
   @Value("\${mailcatcher.api.port}") private val mailcatcherApiPort: Int,
@@ -196,7 +196,7 @@ class MagicLinkResourceTest(
         .body(BodyInserters.fromValue("""{ "secret": "some-secret" }"""))
         .exchange()
         .expectStatus().isCreated
-        .returnResult(MagicLinkResource.VerifyLinkResponse::class.java)
+        .returnResult(VerifyLinkResponse::class.java)
         .responseBody
         .blockFirst()
         ?: fail("Did not receive a response from /link/verify")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkRequestValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkRequestValidatorTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.ErrorCode
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.ValidationException
+
+class MagicLinkRequestValidatorTest {
+
+  private val magicLinkRequestValidator = MagicLinkRequestValidator()
+  private val emailOfMaxLength = """${"a".repeat(32)}.${"b".repeat(31)}@${"c".repeat(180)}.cjsm.net"""
+
+  @Test
+  fun `email of maximum length should not throw validation exception`() {
+    magicLinkRequestValidator.validate(MagicLinkRequest(emailOfMaxLength))
+  }
+
+  @Test
+  fun `email greater than maximum length should throw validation exception`() {
+    assertThatThrownBy {
+      magicLinkRequestValidator.validate(MagicLinkRequest("a$emailOfMaxLength"))
+    }.isInstanceOf(ValidationException::class.java)
+      .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_TOO_LONG)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/JwtServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/JwtServiceTest.kt
@@ -47,12 +47,12 @@ class JwtServiceTest {
   fun `the generated JWT should expire at midnight on the day of expiry`() {
     val jwtService = jwtService(
       expiry = Duration.of(1, ChronoUnit.DAYS),
-      clock = Clock.fixed(Instant.parse("2021-11-26T12:18:05Z"), ZoneId.of("Europe/London"))
+      clock = Clock.fixed(Instant.parse("2100-11-26T12:18:05Z"), ZoneId.of("Europe/London"))
     )
     val jwt = jwtService.generateToken("some.email@company.com")
 
     val expiresAt = jwtService.expiresAt(jwt)
-    assertThat(expiresAt).isEqualTo(Instant.parse("2021-11-28T00:00:00Z"))
+    assertThat(expiresAt).isEqualTo(Instant.parse("2100-11-28T00:00:00Z"))
   }
 
   @Test


### PR DESCRIPTION
And fix a test that relies on a valid JWT