### PR TITLE
SLM-14 apply random checks and return barcode created by

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
@@ -89,10 +89,14 @@ class BarcodeResource(private val barcodeService: BarcodeService, private val us
   fun checkBarcode(
     @Parameter(hidden = true) @AuthenticationPrincipal userId: String,
     @RequestBody request: CheckBarcodeRequest,
-  ) = barcodeService.checkBarcode(userId, request.barcode, userContext.caseload)
+  ) = CheckBarcodeResponse(barcodeService.checkBarcode(userId, request.barcode, userContext.caseload))
 }
 
 data class CheckBarcodeRequest(
   @Schema(description = "The barcode being checked", example = "123456789012", required = true)
   val barcode: String,
+)
+data class CheckBarcodeResponse(
+  @Schema(description = "The organisation that created the barcode", example = "Aardvark Lawyers", required = true)
+  val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeService.kt
@@ -22,7 +22,7 @@ class BarcodeService(
     return barcodeRepository.save(Barcode(barcode))
   }
 
-  fun checkBarcode(userId: String, code: String, location: String) {
+  fun checkBarcode(userId: String, code: String, location: String): String =
     barcodeRepository.findById(code).orElseGet { barcodeRepository.save(Barcode(code)) }
       .also { barcode ->
         with(barcodeEventService) {
@@ -33,5 +33,5 @@ class BarcodeService(
           checkForRandomSecurityCheck(barcode, userId, location)
         }
       }
-  }
+      .let { barcode -> barcodeEventService.getCreatedBy(barcode) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeService.kt
@@ -30,6 +30,7 @@ class BarcodeService(
           checkForCreated(barcode)
           checkForDuplicate(barcode, userId, location)
           checkForExpired(barcode, userId, location)
+          checkForRandomSecurityCheck(barcode, userId, location)
         }
       }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ErrorCodes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ErrorCodes.kt
@@ -22,9 +22,12 @@ object EmailInvalid : MagicLinkRequestErrorCodes("INVALID_EMAIL", "Enter an emai
 object EmailInvalidCjsm : MagicLinkRequestErrorCodes("INVALID_CJSM_EMAIL", "Enter an email address which ends with 'cjsm.net'")
 
 sealed class CheckBarcodeErrorCodes(code: String, userMessage: String) : StandardErrorCodes(code, userMessage)
-class Duplicate(val scannedDate: Instant, val scannedLocation: String) : CheckBarcodeErrorCodes("DUPLICATE", "Someone scanned this barcode ${scannedDate.formatAtTimeOnDate()} at $scannedLocation. It may be an illegal copy.")
-class Expired(val createdDate: Instant, val barcodeExpiryDays: Long) : CheckBarcodeErrorCodes("EXPIRED", "This barcode was created ${createdDate.ageInDays()}, ${createdDate.formatOnDate()}.")
-object RandomCheck : CheckBarcodeErrorCodes("RANDOM_CHECK", "For additional security this barcode has been selected for a random check")
+class Duplicate(val scannedDate: Instant, val scannedLocation: String, val createdBy: String) :
+  CheckBarcodeErrorCodes("DUPLICATE", "Someone scanned this barcode ${scannedDate.formatAtTimeOnDate()} at $scannedLocation. It may be an illegal copy.")
+class Expired(val createdDate: Instant, val barcodeExpiryDays: Long, val createdBy: String) :
+  CheckBarcodeErrorCodes("EXPIRED", "This barcode was created ${createdDate.ageInDays()}, ${createdDate.formatOnDate()}.")
+class RandomCheck(val createdBy: String) :
+  CheckBarcodeErrorCodes("RANDOM_CHECK", "For additional security this barcode has been selected for a random check")
 
 private val timeFormatter = DateTimeFormatter.ofPattern("h:mm a").withZone(ZoneId.systemDefault())
 private val dateFormatter = DateTimeFormatter.ofPattern("d MMMM y").withZone(ZoneId.systemDefault())

--- a/src/main/resources/db/migration/V1_4__barcode_events_status_length.sql
+++ b/src/main/resources/db/migration/V1_4__barcode_events_status_length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE barcode_events ALTER COLUMN status TYPE VARCHAR(20);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeEventServiceTest.kt
@@ -192,7 +192,7 @@ class BarcodeEventServiceTest {
   }
 
   @Nested
-  inner class GetCeatedBy {
+  inner class GetCreatedBy {
     @Test
     fun `Will return the user that created the barcode`() {
       mockFindBarcodeEvents(CREATED, listOf(aBarcodeEvent(userId = "some_user", status = CREATED)))
@@ -200,6 +200,15 @@ class BarcodeEventServiceTest {
       val createdBy = barcodeEventService.getCreatedBy(aBarcode())
 
       assertThat(createdBy).isEqualTo("some_user")
+    }
+
+    @Test
+    fun `Will return with error text if cannot find user created event - in theory this cannot happen`() {
+      mockFindBarcodeEvents(CREATED, listOf())
+
+      val createdBy = barcodeEventService.getCreatedBy(aBarcode())
+
+      assertThat(createdBy).contains("error")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeEventServiceTest.kt
@@ -191,6 +191,18 @@ class BarcodeEventServiceTest {
     }
   }
 
+  @Nested
+  inner class GetCeatedBy {
+    @Test
+    fun `Will return the user that created the barcode`() {
+      mockFindBarcodeEvents(CREATED, listOf(aBarcodeEvent(userId = "some_user", status = CREATED)))
+
+      val createdBy = barcodeEventService.getCreatedBy(aBarcode())
+
+      assertThat(createdBy).isEqualTo("some_user")
+    }
+  }
+
   // Test helpers
   private fun aBarcode() = Barcode("SOME_BARCODE")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeServiceTest.kt
@@ -8,7 +8,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.ArgumentMatchers.anyString
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.Duplicate
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.Expired
@@ -50,11 +49,11 @@ class BarcodeServiceTest {
     @Test
     fun `should complete ok and create checked event if barcode exists`() {
       mockFindBarcode()
+      whenever(barcodeEventService.getCreatedBy(aBarcode())).thenReturn("some_sender")
 
-      assertDoesNotThrow {
-        barcodeService.checkBarcode("some_user", "SOME_BARCODE", "some_location")
-      }
+      val createdBy = barcodeService.checkBarcode("some_user", "SOME_BARCODE", "some_location")
 
+      assertThat(createdBy).isEqualTo("some_sender")
       verify(barcodeEventService)
         .createEvent(aBarcode(), "some_user", BarcodeStatus.CHECKED, "some_location")
     }
@@ -82,7 +81,7 @@ class BarcodeServiceTest {
     @Test
     fun `should throw validation exception and create checked event if duplicate`() {
       val yesterday = Instant.now().minus(1, ChronoUnit.DAYS)
-      val expectedException = ValidationException(Duplicate(yesterday, "previous_location"))
+      val expectedException = ValidationException(Duplicate(yesterday, "previous_location", "some_sender"))
       mockFindBarcode()
       whenever(barcodeEventService.checkForDuplicate(aBarcode(), "current_user", "current_location"))
         .thenThrow(expectedException)
@@ -102,7 +101,7 @@ class BarcodeServiceTest {
     @Test
     fun `should throw validation exception and create checked event if duplicate`() {
       val expired = Instant.now().minus(barcodeExpiryDays + 1, ChronoUnit.DAYS)
-      val expectedException = ValidationException(Expired(expired, barcodeExpiryDays))
+      val expectedException = ValidationException(Expired(expired, barcodeExpiryDays, "some_sender"))
       mockFindBarcode()
       whenever(barcodeEventService.checkForExpired(aBarcode(), "current_user", "current_location"))
         .thenThrow(expectedException)
@@ -119,7 +118,7 @@ class BarcodeServiceTest {
   inner class CheckBarcodeRandomSecurityCheck {
     @Test
     fun `should throw validation exception and create checked event if duplicate`() {
-      val expectedException = ValidationException(RandomCheck)
+      val expectedException = ValidationException(RandomCheck("some_sender"))
       mockFindBarcode()
       whenever(barcodeEventService.checkForRandomSecurityCheck(aBarcode(), "current_user", "current_location"))
         .thenThrow(expectedException)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ErrorCodesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ErrorCodesTest.kt
@@ -14,7 +14,7 @@ class ErrorCodesTest {
   inner class Duplicate {
     @Test
     fun `should format the user message correctly`() {
-      val ex = Duplicate(Instant.parse("2021-12-08T09:11:23Z"), "some_location")
+      val ex = Duplicate(Instant.parse("2021-12-08T09:11:23Z"), "some_location", "sender")
 
       assertThat(ex.userMessage).contains("at 9:11 am on 8 December 2021")
     }
@@ -27,7 +27,7 @@ class ErrorCodesTest {
       val createdTime = Instant.now().minus(55, ChronoUnit.DAYS)
       val createdTimeString =
         DateTimeFormatter.ofPattern("d MMMM y").withZone(ZoneId.systemDefault()).format(createdTime)
-      val ex = Expired(createdTime, 28)
+      val ex = Expired(createdTime, 28, "sender")
 
       assertThat(ex.userMessage).contains("55 days ago")
       assertThat(ex.userMessage).contains(createdTimeString)

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/E2eTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/E2eTest.kt
@@ -103,19 +103,22 @@ class E2eTest(
       .uri("/barcode/check")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+      .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
       .body(BodyInserters.fromValue("""{ "barcode": "$barcode" }"""))
       .exchange()
       .expectStatus().isOk
+      .expectBody().jsonPath("$.createdBy").isEqualTo("some.email@company.com.cjsm.net")
 
   private fun requestCheckBarcodeDuplicate(barcode: String) =
     webTestClient.post()
       .uri("/barcode/check")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+      .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
       .body(BodyInserters.fromValue("""{ "barcode": "$barcode" }"""))
       .exchange()
       .expectStatus().isBadRequest
-      .expectBody().jsonPath("$.errorCode.code").isEqualTo("DUPLICATE")
+      .expectBody()
+      .jsonPath("$.errorCode.code").isEqualTo("DUPLICATE")
+      .jsonPath("$.errorCode.createdBy").isEqualTo("some.email@company.com.cjsm.net")
 }

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/IntegrationTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/IntegrationTest.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi
 
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
 import io.lettuce.core.ClientOptions
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.data.redis.LettuceClientConfigurationBuilderCustomizer
@@ -21,9 +24,9 @@ import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.barcode.BarcodeCon
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.barcode.BarcodeEventRepository
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.barcode.BarcodeGeneratorService
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.barcode.BarcodeRepository
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.barcode.RandomCheckService
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MagicLinkConfig
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MagicLinkSecretRepository
-import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MagicLinkService
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.mocks.HmppsAuthExtension
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security.JwtService
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.testcontainers.MailcatcherContainer
@@ -60,19 +63,24 @@ abstract class IntegrationTest {
   protected lateinit var magicLinkConfig: MagicLinkConfig
 
   @Autowired
-  protected lateinit var magicLinkService: MagicLinkService
-
-  @Autowired
   protected lateinit var jwtService: JwtService
 
   @SpyBean
   protected lateinit var barcodeConfig: BarcodeConfig
+
+  @SpyBean
+  protected lateinit var randomCheckService: RandomCheckService
 
   @AfterEach
   fun `clear database`() {
     barcodeEventRepository.deleteAll()
     barcodeRepository.deleteAll()
     magicLinkSecretRepository.deleteAll()
+  }
+
+  @BeforeEach
+  fun `turn off random checks`() {
+    doReturn(false).whenever(randomCheckService).requiresRandomCheck()
   }
 
   internal fun setAuthorisation(

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResourceTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResourceTest.kt
@@ -36,7 +36,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com"))
+        .headers(setAuthorisation(user = "AUSER_GEN"))
         .exchange()
         .expectStatus().isForbidden
         .expectBody().jsonPath("$.errorCode.code").isEqualTo(AuthenticationError.code)
@@ -136,7 +136,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode/check")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+        .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
         .body(BodyInserters.fromValue("""{ "barcode": "doesnt-exist" }"""))
         .exchange()
         .expectStatus().isNotFound
@@ -159,10 +159,11 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode/check")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+        .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
         .body(BodyInserters.fromValue("""{ "barcode": "SOME_BARCODE" }"""))
         .exchange()
         .expectStatus().isOk
+        .expectBody().jsonPath("$.createdBy").isEqualTo("some.user@company.com.cjsm.net")
     }
 
     @Test
@@ -181,7 +182,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode/check")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+        .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
         .body(BodyInserters.fromValue("""{ "barcode": "SOME_BARCODE" }"""))
         .exchange()
         .expectStatus().isOk
@@ -191,7 +192,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode/check")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+        .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
         .body(BodyInserters.fromValue("""{ "barcode": "SOME_BARCODE" }"""))
         .exchange()
         .expectStatus().isBadRequest
@@ -199,6 +200,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .jsonPath("$.errorCode.code").isEqualTo("DUPLICATE")
         .jsonPath("$.errorCode.scannedDate").value<String> { assertThat(it).contains(today) }
         .jsonPath("$.errorCode.scannedLocation").isEqualTo("LEI")
+        .jsonPath("$.errorCode.createdBy").isEqualTo("some.user@company.com.cjsm.net")
     }
 
     @Test
@@ -219,7 +221,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode/check")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+        .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
         .body(BodyInserters.fromValue("""{ "barcode": "SOME_BARCODE" }"""))
         .exchange()
         .expectStatus().isBadRequest
@@ -227,6 +229,7 @@ class BarcodeResourceTest : IntegrationTest() {
         .jsonPath("$.errorCode.code").isEqualTo("EXPIRED")
         .jsonPath("$.errorCode.barcodeExpiryDays").isEqualTo("0")
         .jsonPath("$.errorCode.createdDate").value<String> { assertThat(it).contains(expiredDayString) }
+        .jsonPath("$.errorCode.createdBy").isEqualTo("some.user@company.com.cjsm.net")
     }
 
     @Test
@@ -246,12 +249,13 @@ class BarcodeResourceTest : IntegrationTest() {
         .uri("/barcode/check")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "some.user@domain.com", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
+        .headers(setAuthorisation(user = "AUSER_GEN", roles = listOf("ROLE_SLM_SCAN_BARCODE")))
         .body(BodyInserters.fromValue("""{ "barcode": "SOME_BARCODE" }"""))
         .exchange()
         .expectStatus().isBadRequest
         .expectBody()
         .jsonPath("$.errorCode.code").isEqualTo("RANDOM_CHECK")
+        .jsonPath("$.errorCode.createdBy").isEqualTo("some.user@company.com.cjsm.net")
     }
   }
 }


### PR DESCRIPTION
* Call the random check service from the barcode check service
* Return the user that created the barcode if OK
* Return the user that created the barcode for DUPLICATE, EXPIRED and RANDOM_CHECK errors
* Rename some users to make it clearer which are external (cjsm email) or DPS (ends with _GEN)