### PR TITLE
SLM-14 missing openapi docs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
@@ -67,7 +67,7 @@ class BarcodeResource(private val barcodeService: BarcodeService, private val us
       ApiResponse(
         responseCode = "200",
         description = "Barcode is OK and no further checks are required",
-        content = [Content(mediaType = "application/json")],
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = CheckBarcodeResponse::class))],
       ),
       ApiResponse(
         responseCode = "400",
@@ -97,6 +97,6 @@ data class CheckBarcodeRequest(
   val barcode: String,
 )
 data class CheckBarcodeResponse(
-  @Schema(description = "The organisation that created the barcode", example = "Aardvark Lawyers", required = true)
+  @Schema(description = "The organisation that created the barcode", example = "Aardvark Solicitors", required = true)
   val createdBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/barcode/BarcodeResource.kt
@@ -71,7 +71,7 @@ class BarcodeResource(private val barcodeService: BarcodeService, private val us
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Bad request",
+        description = "Bad request. For specific errors see the Schema for CheckBarcodeErrorCodes",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ErrorCodes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ErrorCodes.kt
@@ -1,33 +1,72 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink.MAX_EMAIL_LENGTH
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-sealed class ErrorCode(val code: String, val userMessage: String)
+@Schema(subTypes = [StandardErrorCodes::class, MagicLinkRequestErrorCodes::class, CheckBarcodeErrorCodes::class])
+sealed class ErrorCode(
+  @Schema(description = "The error code", example = "ERROR_IDENTIFIER")
+  val code: String,
+  @Schema(description = "A human readable description of the error", example = "An error occurred")
+  val userMessage: String
+)
 
-sealed class StandardErrorCodes(code: String, userMessage: String) : ErrorCode(code, userMessage)
+@Schema(oneOf = [AuthenticationError::class, DownstreamError::class, InternalError::class, MalformedRequest::class, NotFound::class])
+sealed class StandardErrorCodes(
+  @Schema(allowableValues = ["AUTH", "DOWNSTREAM", "INTERNAL_ERROR", "MALFORMED_REQUEST", "NOT_FOUND"])
+  code: String,
+  userMessage: String
+) : ErrorCode(code, userMessage)
 object AuthenticationError : StandardErrorCodes("AUTH", "Authentication failure")
 object DownstreamError : StandardErrorCodes("DOWNSTREAM", "An error occurred calling a downstream service")
 object InternalError : StandardErrorCodes("INTERNAL_ERROR", "An unexpected error occurred")
 object MalformedRequest : StandardErrorCodes("MALFORMED_REQUEST", "Failed to read the payload")
 object NotFound : StandardErrorCodes("NOT_FOUND", "Not found")
 
-sealed class MagicLinkRequestErrorCodes(code: String, userMessage: String) : StandardErrorCodes(code, userMessage)
+@Schema(oneOf = [EmailMandatory::class, EmailTooLong::class, EmailInvalid::class, EmailInvalidCjsm::class])
+sealed class MagicLinkRequestErrorCodes(
+  @Schema(allowableValues = ["EMAIL_MANDATORY", "EMAIL_TOO_LONG", "INVALID_EMAIL", "INVALID_CJSM_EMAIL"])
+  code: String,
+  userMessage: String
+) : StandardErrorCodes(code, userMessage)
 object EmailMandatory : MagicLinkRequestErrorCodes("EMAIL_MANDATORY", "The email address must be entered")
 object EmailTooLong : MagicLinkRequestErrorCodes("EMAIL_TOO_LONG", "The email address can have a maximum length of $MAX_EMAIL_LENGTH")
 object EmailInvalid : MagicLinkRequestErrorCodes("INVALID_EMAIL", "Enter an email address in the correct format")
 object EmailInvalidCjsm : MagicLinkRequestErrorCodes("INVALID_CJSM_EMAIL", "Enter an email address which ends with 'cjsm.net'")
 
-sealed class CheckBarcodeErrorCodes(code: String, userMessage: String) : StandardErrorCodes(code, userMessage)
-class Duplicate(val scannedDate: Instant, val scannedLocation: String, val createdBy: String) :
-  CheckBarcodeErrorCodes("DUPLICATE", "Someone scanned this barcode ${scannedDate.formatAtTimeOnDate()} at $scannedLocation. It may be an illegal copy.")
-class Expired(val createdDate: Instant, val barcodeExpiryDays: Long, val createdBy: String) :
-  CheckBarcodeErrorCodes("EXPIRED", "This barcode was created ${createdDate.ageInDays()}, ${createdDate.formatOnDate()}.")
-class RandomCheck(val createdBy: String) :
-  CheckBarcodeErrorCodes("RANDOM_CHECK", "For additional security this barcode has been selected for a random check")
+@Schema(oneOf = [Duplicate::class, Expired::class, RandomCheck::class])
+sealed class CheckBarcodeErrorCodes(
+  @Schema(allowableValues = ["DUPLICATE", "EXPIRED", "RANDOM_CHECK"])
+  code: String,
+  userMessage: String
+) : StandardErrorCodes(code, userMessage)
+
+class Duplicate(
+  @Schema(description = "The time that the original barcode was scanned", example = "2021-11-30T09:06:10Z")
+  val scannedDate: Instant,
+  @Schema(description = "The prison where the original barcode was scanned", example = "MDI")
+  val scannedLocation: String,
+  @Schema(description = "The organisation that created the barcode in the first place", example = "Aardvark Solicitors")
+  val createdBy: String,
+) : CheckBarcodeErrorCodes("DUPLICATE", "Someone scanned this barcode ${scannedDate.formatAtTimeOnDate()} at $scannedLocation. It may be an illegal copy.")
+
+class Expired(
+  @Schema(description = "The time the barcode was created", example = "2021-11-30T09:06:10Z")
+  val createdDate: Instant,
+  @Schema(description = "The number of days before a barcode expires", example = "28")
+  val barcodeExpiryDays: Long,
+  @Schema(description = "The organisation that created the barcode in the first place", example = "Aardvark Solicitors")
+  val createdBy: String
+) : CheckBarcodeErrorCodes("EXPIRED", "This barcode was created ${createdDate.ageInDays()}, ${createdDate.formatOnDate()}.")
+
+class RandomCheck(
+  @Schema(description = "The organisation that created the barcode in the first place", example = "Aardvark Solicitors")
+  val createdBy: String
+) : CheckBarcodeErrorCodes("RANDOM_CHECK", "For additional security this barcode has been selected for a random check")
 
 private val timeFormatter = DateTimeFormatter.ofPattern("h:mm a").withZone(ZoneId.systemDefault())
 private val dateFormatter = DateTimeFormatter.ofPattern("d MMMM y").withZone(ZoneId.systemDefault())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ExceptionHandler.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config
 
+import io.swagger.v3.oas.annotations.media.Schema
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
@@ -79,6 +80,11 @@ class SendLegalMailToPrisonsApiExceptionHandler {
 
 class ValidationException(val errorCode: ErrorCode) : RuntimeException()
 
-class ErrorResponse(val status: Int, val errorCode: ErrorCode) {
+class ErrorResponse(
+  @Schema(description = "The HTTP status code", example = "400")
+  val status: Int,
+  @Schema(description = "The error code describing the error")
+  val errorCode: ErrorCode
+) {
   constructor(status: HttpStatus, errorCode: ErrorCode) : this(status.value(), errorCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkResource.kt
@@ -40,6 +40,11 @@ class MagicLinkResource(
         ],
       ),
       ApiResponse(
+        responseCode = "400",
+        description = "Bad request. For specific errors see the Schema for MagicLinkRequestErrorCodes",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
         responseCode = "401",
         description = "Unauthorised, requires a valid Oauth2 token",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,6 +83,9 @@ management:
       cache:
         time-to-live: 2000ms
 
+springdoc:
+  remove-broken-reference-definitions: false
+
 app:
   magiclink:
     secret-expiry: 1h


### PR DESCRIPTION
* Export types for returned error codes which have various data structures
* But cut the OpenAPI doc link between ErrorCode and its descendents - otherwise every possible error code appears to be available for every ErrorResponse