### PR TITLE
SLM-39: Updated magic link email content

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSender.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink
 
-import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Service
 
 @Service
@@ -10,12 +10,61 @@ class MagicLinkEmailSender(
   private val javaMailSender: JavaMailSender,
 ) {
 
-  fun send(email: String, secret: String) {
-    SimpleMailMessage().apply {
-      setTo(email)
-      subject = "Send Legal Mail Sign in"
-      text = "${magicLinkConfig.url}?secret=$secret"
-    }
-      .also { javaMailSender.send(it) }
+  private companion object {
+    val TEXT_BODY_TEMPLATE: String = """
+      You requested a link to log in to Send legal mail to prisons.
+
+      Click on the link or paste it into your browser:
+      %s
+
+      You have %s to use the link.
+
+      If you didn't request a link you can ignore this email.
+      From HMPPS Digital
+    """.trimIndent()
+
+    val HTML_BODY_TEMPLATE: String = """
+      <html>
+      <head></head>
+      <body>
+        <p>
+          You requested a link to log in to Send legal mail to prisons.
+        </p>
+
+        <p>
+          Click on the link or paste it into your browser:<br/>
+          <a href="%s">%s</a>
+        </p>
+
+        <p>You have %s to use the link.</p>
+
+        <p>
+          If you didn't request a link you can ignore this email.<br/>
+          From HMPPS Digital
+        </p>
+      </body>
+      </html>
+    """.trimIndent()
   }
+
+  fun send(email: String, secret: String) {
+    val magicLink = "${magicLinkConfig.url}?secret=$secret"
+    val magicLinkExpiry = "${magicLinkConfig.secretExpiry.toMinutes()} minutes"
+
+    javaMailSender.createMimeMessage()
+      .also { mimeMessage ->
+        MimeMessageHelper(mimeMessage, true).apply {
+          setTo(email)
+          setSubject("Send Legal Mail Sign in")
+          setText(textBody(magicLink, magicLinkExpiry), htmlBody(magicLink, magicLinkExpiry))
+        }
+      }
+      .also { mimeMessage ->
+        javaMailSender.send(mimeMessage)
+      }
+  }
+
+  private fun textBody(magicLink: String, magicLinkExpiry: String) = String.format(TEXT_BODY_TEMPLATE, magicLink, magicLinkExpiry)
+
+  private fun htmlBody(magicLink: String, magicLinkExpiry: String) = String.format(HTML_BODY_TEMPLATE, magicLink, magicLink, magicLinkExpiry)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/magiclink/MagicLinkEmailSenderTest.kt
@@ -3,27 +3,53 @@ package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.magiclink
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.check
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+import javax.mail.Session
+import javax.mail.internet.MimeMessage
+import javax.mail.internet.MimeMultipart
 
 class MagicLinkEmailSenderTest {
 
   private val mockMailSender: JavaMailSender = mock()
-  private val magicLinkEmailSender = MagicLinkEmailSender(MagicLinkConfig(Duration.of(0, ChronoUnit.SECONDS), "some-url"), mockMailSender)
+  private val magicLinkEmailSender = MagicLinkEmailSender(MagicLinkConfig(Duration.of(10, ChronoUnit.MINUTES), "some-url"), mockMailSender)
 
   @Test
   fun `The mail should be sent to the user with a magic link`() {
+    val session: Session? = null
+    val mimeMessage = MimeMessage(session)
+    given(mockMailSender.createMimeMessage()).willReturn(mimeMessage)
+
     magicLinkEmailSender.send("an.email@company.com", "this-is-a-secret")
 
     verify(mockMailSender).send(
-      check<SimpleMailMessage> {
-        assertThat(it.to).isEqualTo(arrayOf("an.email@company.com"))
-        assertThat(it.text).contains("some-url?secret=this-is-a-secret")
+      check<MimeMessage> {
+        assertThat(it.subject).isEqualTo("Send Legal Mail Sign in")
+        assertThat(it.allRecipients.map { recipient -> recipient.toString() }).isEqualTo(listOf("an.email@company.com"))
+
+        val bodyPartContents = (it.content as MimeMultipart).getBodyPartContents()
+        assertThat(bodyPartContents["text/plain"]).contains("10 minutes")
+        assertThat(bodyPartContents["text/plain"]).contains("some-url?secret=this-is-a-secret")
+        assertThat(bodyPartContents["text/html"]).contains("10 minutes")
+        assertThat(bodyPartContents["text/html"]).contains("<a href=\"some-url?secret=this-is-a-secret\"")
       }
     )
+  }
+
+  private fun MimeMultipart.getBodyPartContents(): Map<String, String> {
+    val bodyPartContents: MutableMap<String, String> = mutableMapOf()
+    for (idx in 0 until this.count) {
+      val bodyPart = this.getBodyPart(idx)
+      if (bodyPart.content is MimeMultipart) {
+        bodyPartContents.putAll((bodyPart.content as MimeMultipart).getBodyPartContents())
+      } else {
+        bodyPartContents[bodyPart.dataHandler.contentType.substringBefore(";")] = bodyPart.dataHandler.content.toString()
+      }
+    }
+    return bodyPartContents.toMap()
   }
 }

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/E2eTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/E2eTest.kt
@@ -59,7 +59,7 @@ class E2eTest(
       .retrieve()
       .bodyToMono(Message::class.java)
       .block() as Message
-    val (secretValue) = ".*secret=(.*)$".toRegex().find(message.source)!!.destructured
+    val (secretValue) = ".*secret=(.*)".toRegex().find(message.source)!!.destructured
     return secretValue
   }
 


### PR DESCRIPTION
Updated magic link email content; including plain text and html content alternates (multipart mime)