### PR TITLE
SLM-63 get contact by id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResource.kt
@@ -174,7 +174,45 @@ class ContactResource(private val contactService: ContactService) {
       ?: throw ResourceNotFoundException("Contact not found")
   }
 
+  @Deprecated("TODO SLM-63 to be replaced by /contact/prisonNumber/{prisonNumber}")
   @GetMapping(value = ["/contact/{prisonNumber}"])
+  @ResponseBody
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_SLM_CREATE_BARCODE')")
+  @Operation(
+    summary = "Retrieve a Contact by prisonNumber for the logged in user",
+    security = [SecurityRequirement(name = "ROLE_SLM_CREATE_BARCODE")],
+    parameters = [Parameter(`in` = ParameterIn.PATH, name = "prisonNumber", example = "A1234BC", description = "The prison number of the Contact to return.")]
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Contact returned",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ContactResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid magic link token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires a valid token with role ROLE_SLM_CREATE_BARCODE",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Contact not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun getContactByPrisonNumberOld(@PathVariable prisonNumber: String, authentication: Authentication): ContactResponse =
+    contactService.getContactByPrisonNumber(authentication.name, prisonNumber)
+      ?: throw ResourceNotFoundException("Could not find a matching Contact [${authentication.name}, $prisonNumber]")
+
+  @GetMapping(value = ["/contact/prisonNumber/{prisonNumber}"])
   @ResponseBody
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_SLM_CREATE_BARCODE')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResource.kt
@@ -36,6 +36,50 @@ import javax.validation.constraints.Size
 @RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactResource(private val contactService: ContactService) {
 
+  // TODO SLM-63 Switch this back to /contact/{id} once we have switched the UI to use the new prisonNumber endpoint
+  @GetMapping(value = ["/contact/id/{id}"])
+  @ResponseBody
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_SLM_CREATE_BARCODE')")
+  @Operation(
+    summary = "Retrieve an existing Contact for the signed in user",
+    security = [SecurityRequirement(name = "ROLE_SLM_CREATE_BARCODE")]
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Contact udpated",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ContactResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid CJSM email link token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires a valid token with role ROLE_SLM_CREATE_BARCODE",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Contact not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun getContact(
+    @PathVariable id: Long,
+    authentication: Authentication
+  ): ContactResponse = contactService.getContact(authentication.name, id)
+    ?: throw ResourceNotFoundException("Contact not found")
+
   @PostMapping(value = ["/contact"])
   @ResponseBody
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactService.kt
@@ -9,6 +9,10 @@ import java.time.Instant
 @Service
 class ContactService(private val contactRepository: ContactRepository, private val clock: Clock) {
 
+  fun getContact(userId: String, contactId: Long): ContactResponse? =
+    contactRepository.getContactByOwnerAndId(owner = userId, id = contactId)
+      ?.let { toContactResponse(it) }
+
   fun createContact(userId: String, contactRequest: ContactRequest): ContactResponse {
     val now = Instant.now(clock)
     val newContactEntity = Contact(

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResourceGetContactByIdTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResourceGetContactByIdTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.contact
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.IntegrationTest
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.AuthenticationError
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.NotFound
+import java.time.format.DateTimeFormatter
+
+@Sql("/createContacts.sql")
+class ContactResourceGetContactByIdTest : IntegrationTest() {
+  val testContact by lazy { contactRepository.findAll().first { it.dob != null } }
+
+  @Test
+  fun `unauthorised without a valid auth token`() {
+    webTestClient.get()
+      .uri("/contact/id/${testContact.id}")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  fun `forbidden without a valid role`() {
+    webTestClient.get()
+      .uri("/contact/id/${testContact.id}")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(user = "AUSER_GEN"))
+      .exchange()
+      .expectStatus().isForbidden
+      .expectBody().jsonPath("$.errorCode.code").isEqualTo(AuthenticationError.code)
+  }
+
+  @Test
+  fun `not found given unknown id`() {
+    webTestClient.get()
+      .uri("/contact/id/99999")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setCreateBarcodeAuthorisation())
+      .exchange()
+      .expectStatus().isNotFound
+      .expectBody().jsonPath("$.errorCode.code").isEqualTo(NotFound.code)
+  }
+
+  @Test
+  fun `returns contact given valid prison number`() {
+    webTestClient.get()
+      .uri("/contact/id/${testContact.id}")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setCreateBarcodeAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(testContact.id)
+      .jsonPath("$.prisonerName").isEqualTo(testContact.name)
+      .jsonPath("$.prisonNumber").isEqualTo(testContact.prisonNumber)
+      .jsonPath("$.dob").isEqualTo(DateTimeFormatter.ISO_LOCAL_DATE.format(testContact.dob))
+      .jsonPath("$.prisonId").isEqualTo(testContact.prisonCode)
+  }
+}

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResourceGetContactByPrisonNumberTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/contact/ContactResourceGetContactByPrisonNumberTest.kt
@@ -7,13 +7,12 @@ import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.IntegrationTest
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.AuthenticationError
 import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.NotFound
 
-@Deprecated("@TODO SLM-63 Remove when /contact/{prisonNumber} is deleted")
 @Sql("/createContacts.sql")
-class ContactResourceGetContactTest : IntegrationTest() {
+class ContactResourceGetContactByPrisonNumberTest : IntegrationTest() {
   @Test
   fun `unauthorised without a valid auth token`() {
     webTestClient.get()
-      .uri("/contact/A1234BC")
+      .uri("/contact/prisonNumber/A1234BC")
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isUnauthorized
@@ -22,7 +21,7 @@ class ContactResourceGetContactTest : IntegrationTest() {
   @Test
   fun `forbidden without a valid role`() {
     webTestClient.get()
-      .uri("/contact/A1234BC")
+      .uri("/contact/prisonNumber/A1234BC")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(user = "AUSER_GEN"))
       .exchange()
@@ -33,7 +32,7 @@ class ContactResourceGetContactTest : IntegrationTest() {
   @Test
   fun `not found given unknown prison number`() {
     webTestClient.get()
-      .uri("/contact/X9999ZZ")
+      .uri("/contact/prisonNumber/X9999ZZ")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setCreateBarcodeAuthorisation())
       .exchange()
@@ -44,7 +43,7 @@ class ContactResourceGetContactTest : IntegrationTest() {
   @Test
   fun `returns contact given valid prison number`() {
     webTestClient.get()
-      .uri("/contact/A1234BC")
+      .uri("/contact/prisonNumber/A1234BC")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setCreateBarcodeAuthorisation())
       .exchange()


### PR DESCRIPTION
First of a few PRs to eventually introduce `GET /contact/{id}` which currently clashes with `GET /contact/{prisonNumber}`
* create new endpoint `GET /contact/prisonNumber/{prisonNumber}`
* deprecate `GET /contact/{prisonNumber}`
* create `GET /contact/id/{id}`