### PR TITLE
Fix cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,7 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
+          cache_key: "v2_0"
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:


### PR DESCRIPTION
The OWASP job is failing both in Circle and locally - we may have updated the orb and Gradle plugin out of sequence so I'm trying the cache key fix which might work in Circle. Can't explain why it's not working locally though 🤷 