### PR TITLE
SLM-200: Set message field on ValidationException superclass constructor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/config/ExceptionHandler.kt
@@ -104,7 +104,7 @@ class SendLegalMailToPrisonsApiExceptionHandler : ResponseEntityExceptionHandler
   }
 }
 
-class ValidationException(val errorCode: ErrorCode) : RuntimeException()
+class ValidationException(val errorCode: ErrorCode) : RuntimeException(errorCode.code)
 
 class DuplicateContactException(val userId: String, val prisonNumber: String) : RuntimeException()
 


### PR DESCRIPTION
ValidationExceptions are now logged like this:
```
2022-03-31 08:33:41.016  INFO 35060 --- [o-auto-1-exec-8] u.g.j.d.h.s.config.ExceptionHandler      : Validation exception: DUPLICATE |  
```
