### PR TITLE
SLM-230: add API to verify one time code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeService.kt
@@ -1,12 +1,19 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.onetimecode
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.cjsm.CjsmService
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.ResourceNotFoundException
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security.JwtService
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security.SmokeTestConfig
 
 @Service
 class OneTimeCodeService(
   private val oneTimeCodeGenerator: OneTimeCodeGenerator,
   private val oneTimeCodeRepository: OneTimeCodeRepository,
   private val oneTimeCodeEmailSender: OneTimeCodeEmailSender,
+  private val jwtService: JwtService,
+  private val cjsmService: CjsmService,
+  private val smokeTestConfig: SmokeTestConfig,
 ) {
 
   fun createAndSendOneTimeCode(email: String, sessionId: String) {
@@ -14,4 +21,22 @@ class OneTimeCodeService(
       .also { oneTimeCode -> oneTimeCodeRepository.save(oneTimeCode) }
       .also { oneTimeCode -> oneTimeCodeEmailSender.send(email, oneTimeCode.code) }
   }
+
+  fun verifyOneTimeCode(code: String, sessionId: String): String =
+    if (code == smokeTestConfig.lsjSecret) {
+      smokeTest()
+    } else {
+      oneTimeCodeRepository.findById(sessionId)
+        .orElseGet { throw ResourceNotFoundException("One Time Code not found") }
+        .takeIf { oneTimeCode -> oneTimeCode.code == code }
+        ?.also { oneTimeCodeRepository.deleteById(sessionId) }
+        ?.let { oneTimeCode -> jwtService.generateToken(oneTimeCode.email, findOrganisation(oneTimeCode.email)) }
+        ?: throw ResourceNotFoundException("One Time Code not found") // TODO - this is where '3 strikes and out' will be handled when we get to that
+    }
+
+  private fun smokeTest(): String = jwtService.generateToken("smoke-test-lsj", "smoke-test-lsj-org")
+
+  private fun findOrganisation(userId: String): String? =
+    cjsmService.findOrganisation(userId)
+      ?.takeIf { it.isNotBlank() }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeResourceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.onetimecode
 
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -41,6 +42,20 @@ class OneTimeCodeResourceTest {
 
       verify(oneTimeCodeRequestValidator).validate(oneTimeCodeRequest)
       verifyNoInteractions(oneTimeCodeService)
+    }
+  }
+
+  @Nested
+  inner class VerifyOneTimeCode {
+    @Test
+    fun `should verify one time code`() {
+      val verifyCodeRequest = VerifyCodeRequest("ABCD", "12345678")
+      given { oneTimeCodeService.verifyOneTimeCode(any(), any()) }.willReturn("a-valid-jwt")
+
+      val verifyCodeResponse = oneTimeCodeResource.verifyMagicLink(verifyCodeRequest)
+
+      assertThat(verifyCodeResponse.token).isEqualTo("a-valid-jwt")
+      verify(oneTimeCodeService).verifyOneTimeCode("ABCD", "12345678")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeServiceTest.kt
@@ -1,16 +1,32 @@
 package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.onetimecode
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.cjsm.CjsmService
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.config.ResourceNotFoundException
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security.JwtService
+import uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.security.SmokeTestConfig
+import java.util.Optional
 
 class OneTimeCodeServiceTest {
 
   private val oneTimeCodeGenerator = mock<OneTimeCodeGenerator>()
   private val oneTimeCodeRepository = mock<OneTimeCodeRepository>()
   private val oneTimeCodeEmailSender = mock<OneTimeCodeEmailSender>()
-  private val oneTimeCodeService = OneTimeCodeService(oneTimeCodeGenerator, oneTimeCodeRepository, oneTimeCodeEmailSender)
+  private val jwtService = mock<JwtService>()
+  private val cjsmService = mock<CjsmService>()
+  private val smokeTestConfig = mock<SmokeTestConfig>()
+
+  private val oneTimeCodeService = OneTimeCodeService(
+    oneTimeCodeGenerator, oneTimeCodeRepository, oneTimeCodeEmailSender, jwtService, cjsmService, smokeTestConfig
+  )
 
   @Test
   fun `should create and send one time code`() {
@@ -24,5 +40,63 @@ class OneTimeCodeServiceTest {
 
     verify(oneTimeCodeRepository).save(OneTimeCode(sessionId, code, email))
     verify(oneTimeCodeEmailSender).send(email, code)
+  }
+
+  @Test
+  fun `should verify one time code and delete it given it exists in the repository`() {
+    val email = "someone@somewhere.cjsm.net"
+    val organisation = "Aardvark Lawyers"
+    val sessionId = "12345678"
+    val code = "ABCD"
+    val oneTimeCode = OneTimeCode(sessionId, code, email)
+    given { oneTimeCodeRepository.findById(any()) }.willReturn(Optional.of(oneTimeCode))
+    given { cjsmService.findOrganisation(any()) }.willReturn(organisation)
+    given { jwtService.generateToken(any(), any()) }.willReturn("a-valid-token")
+
+    val token = oneTimeCodeService.verifyOneTimeCode(code, sessionId)
+
+    assertThat(token).isEqualTo("a-valid-token")
+    verify(oneTimeCodeRepository).findById(sessionId)
+    verify(oneTimeCodeRepository).deleteById(sessionId)
+    verify(cjsmService).findOrganisation(email)
+    verify(jwtService).generateToken(email, organisation)
+  }
+
+  // The behaviour that this test asserts is vital to supporting a '3 strikes' and out approach as and when we get there
+  // IE. not to delete the OneTimeCode from the repository
+  @Test
+  fun `should not verify one time code and not delete from the repository given the code does not match`() {
+    val email = "someone@somewhere.cjsm.net"
+    val sessionId = "12345678"
+    val code = "ABCD"
+    val oneTimeCode = OneTimeCode(sessionId, code, email)
+    given { oneTimeCodeRepository.findById(any()) }.willReturn(Optional.of(oneTimeCode))
+
+    assertThatThrownBy {
+      oneTimeCodeService.verifyOneTimeCode("ZYXW", sessionId)
+    }.isInstanceOf(ResourceNotFoundException::class.java)
+      .hasMessage("One Time Code not found")
+
+    verify(oneTimeCodeRepository).findById(sessionId)
+    verify(oneTimeCodeRepository, never()).deleteById(any())
+    verifyNoInteractions(cjsmService)
+    verifyNoInteractions(jwtService)
+  }
+
+  @Test
+  fun `should not verify one time code given it is not in the repository`() {
+    val sessionId = "12345678"
+    val code = "ABCD"
+    given { oneTimeCodeRepository.findById(any()) }.willReturn(Optional.empty())
+
+    assertThatThrownBy {
+      oneTimeCodeService.verifyOneTimeCode(code, sessionId)
+    }.isInstanceOf(ResourceNotFoundException::class.java)
+      .hasMessage("One Time Code not found")
+
+    verify(oneTimeCodeRepository).findById(sessionId)
+    verify(oneTimeCodeRepository, never()).deleteById(any())
+    verifyNoInteractions(cjsmService)
+    verifyNoInteractions(jwtService)
   }
 }


### PR DESCRIPTION
This PR adds the `POST /oneTimeCode/verify` endpoint to verify a previously created one time code