### PR TITLE
SLM-230: Corrected method name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeResource.kt
@@ -87,7 +87,7 @@ class OneTimeCodeResource(
       ),
     ]
   )
-  fun verifyMagicLink(@RequestBody request: VerifyCodeRequest) =
+  fun verifyOneTimeCode(@RequestBody request: VerifyCodeRequest) =
     VerifyCodeResponse(oneTimeCodeService.verifyOneTimeCode(request.code, request.sessionID))
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeResourceTest.kt
@@ -52,7 +52,7 @@ class OneTimeCodeResourceTest {
       val verifyCodeRequest = VerifyCodeRequest("ABCD", "12345678")
       given { oneTimeCodeService.verifyOneTimeCode(any(), any()) }.willReturn("a-valid-jwt")
 
-      val verifyCodeResponse = oneTimeCodeResource.verifyMagicLink(verifyCodeRequest)
+      val verifyCodeResponse = oneTimeCodeResource.verifyOneTimeCode(verifyCodeRequest)
 
       assertThat(verifyCodeResponse.token).isEqualTo("a-valid-jwt")
       verify(oneTimeCodeService).verifyOneTimeCode("ABCD", "12345678")


### PR DESCRIPTION
PR to correct controller endpoint method name as I blatantly copied from another controller 🤭 ; but it also introduces a conflicting operation name in the OpenAPI docs when importing the types into a client