### PR TITLE
SLM-230: Delete OTC every time it is checked. Do not support retries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeService.kt
@@ -26,12 +26,25 @@ class OneTimeCodeService(
     if (code == smokeTestConfig.lsjSecret) {
       smokeTest()
     } else {
+      // Initial MVP implementation that does not support retries
+      oneTimeCodeRepository.findById(sessionId)
+        .orElseGet { throw ResourceNotFoundException("One Time Code not found") } // OTC for the specified session ID not found
+        .also { oneTimeCodeRepository.deleteById(sessionId) }
+        .takeIf { oneTimeCode -> oneTimeCode.code.equals(code, ignoreCase = true) }
+        ?.let { oneTimeCode -> jwtService.generateToken(oneTimeCode.email, findOrganisation(oneTimeCode.email)) }
+        ?: throw ResourceNotFoundException("One Time Code not found") // OTC for the session ID found, but not matching the specified code
+
+      /*
+      // Implementation that will be the basis of a 3-strikes-and-out retry solution, in that the OTC is not deleted immediately if the code does not match.
+      // However, because no count or state for 3-strikes-and-out is currently in place, codes do not get deleted, and can be repeatedly retried up until
+      // their 30 minute expiration. Likely to be addressed in SLM-233
       oneTimeCodeRepository.findById(sessionId)
         .orElseGet { throw ResourceNotFoundException("One Time Code not found") }
         .takeIf { oneTimeCode -> oneTimeCode.code.equals(code, ignoreCase = true) }
         ?.also { oneTimeCodeRepository.deleteById(sessionId) }
         ?.let { oneTimeCode -> jwtService.generateToken(oneTimeCode.email, findOrganisation(oneTimeCode.email)) }
         ?: throw ResourceNotFoundException("One Time Code not found") // TODO - this is where '3 strikes and out' will be handled when we get to that
+       */
     }
 
   private fun smokeTest(): String = jwtService.generateToken("smoke-test-lsj", "smoke-test-lsj-org")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/onetimecode/OneTimeCodeServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.sendlegalmailtoprisonsapi.onetimecode
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
@@ -85,6 +86,7 @@ class OneTimeCodeServiceTest {
   // The behaviour that this test asserts is vital to supporting a '3 strikes' and out approach as and when we get there
   // IE. not to delete the OneTimeCode from the repository
   @Test
+  @Disabled("Implementation does not currently support this as it presents a security risk - SLM-233 should address this")
   fun `should not verify one time code and not delete from the repository given the code does not match`() {
     val email = "someone@somewhere.cjsm.net"
     val sessionId = "12345678"


### PR DESCRIPTION
PR to fix a security risk with an incomplete implementation.
When checking the OTC we retrieve it from the redis repo by sessionID - if it doesn't exist thats easy, we throw a resource not found exception.
If it does exist we then go on to check the code is the same one presented by the user. If the code matches then we delete the OTC from redis so it cant be re-used and return a JWT - happy days.

If however the OTC does exist in redis but the code presented by the user does not match, then we throw a resource not found exception and must delete the OTC from redis, to prevent it being retried.

Before this PR I'd written the code to leave the OTC in redis so that it could be retried, in readiness for a soon to be worked on ticket to allow a 3-strikes-and-out type approach.
However, without the rest of the code that maintains a count of retries and deletes once you've reached 3, a OTC can be repeatedly retried, iterating over the possible codes until it works - AAAA, AAAB, AAAC, AAAD etc

So for now the code must delete the OTC from redis whether the code matches or not. We can only keep the OTC in redis for a subsequent retry once we have developed the code that maintains a count of how many tries there have been