### PR TITLE
SLM-253 Open getSupportedPrisons endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.2.0"
   id("org.unbroken-dome.test-sets") version "4.0.0"
   kotlin("plugin.spring") version "1.6.21"
   kotlin("plugin.jpa") version "1.6.21"
   id("jacoco")
-  id("org.openapi.generator") version "5.4.0"
+  id("org.openapi.generator") version "6.0.0"
 }
 
 testSets {
@@ -33,19 +33,19 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-webmvc-core:1.6.8")
 
   implementation("io.jsonwebtoken:jjwt:0.9.1")
-  implementation("io.github.microutils:kotlin-logging:2.1.21")
+  implementation("io.github.microutils:kotlin-logging:2.1.23")
 
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.224")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.228")
   implementation("org.apache.commons:commons-csv:1.9.0")
 
   runtimeOnly("org.flywaydb:flyway-core")
-  runtimeOnly("org.postgresql:postgresql:42.3.5")
+  runtimeOnly("org.postgresql:postgresql:42.3.6")
 
   testImplementation("org.testcontainers:postgresql:1.17.2")
   testImplementation("it.ozimov:embedded-redis:0.7.3")
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")
   testImplementation("org.mockito:mockito-inline:4.5.1")
-  testImplementation("io.swagger.parser.v3:swagger-parser-v3:2.0.32")
+  testImplementation("io.swagger.parser.v3:swagger-parser-v3:2.0.33")
   testImplementation("org.testcontainers:localstack:1.17.2")
   testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
   testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/prisons/SupportedPrisonsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/prisons/SupportedPrisonsResource.kt
@@ -27,10 +27,10 @@ class SupportedPrisonsResource(private val supportedPrisonsService: SupportedPri
   @GetMapping
   @ResponseBody
   @ResponseStatus(HttpStatus.OK)
-  @PreAuthorize("hasRole('ROLE_SLM_ADMIN')")
+  @PreAuthorize("hasAnyRole('ROLE_SLM_ADMIN','ROLE_SLM_CREATE_BARCODE')")
   @Operation(
     summary = "Retrieve a list of supported prisons",
-    security = [SecurityRequirement(name = "ROLE_SLM_ADMIN")]
+    security = [SecurityRequirement(name = "ROLE_SLM_ADMIN,ROLE_SLM_CREATE_BARCODE")]
   )
   @ApiResponses(
     value = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/prisons/SupportedPrisonsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/prisons/SupportedPrisonsResource.kt
@@ -27,27 +27,13 @@ class SupportedPrisonsResource(private val supportedPrisonsService: SupportedPri
   @GetMapping
   @ResponseBody
   @ResponseStatus(HttpStatus.OK)
-  @PreAuthorize("hasAnyRole('ROLE_SLM_ADMIN','ROLE_SLM_CREATE_BARCODE')")
-  @Operation(
-    summary = "Retrieve a list of supported prisons",
-    security = [SecurityRequirement(name = "ROLE_SLM_ADMIN,ROLE_SLM_CREATE_BARCODE")]
-  )
+  @Operation(summary = "Retrieve a list of supported prisons")
   @ApiResponses(
     value = [
       ApiResponse(
         responseCode = "200",
         description = "Supported prisons returned",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = SupportedPrisons::class))],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorised, requires a valid authentication token",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Forbidden, requires a valid authentication token with role ROLE_SLM_ADMIN",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
     ]
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/security/ResourceServerConfiguration.kt
@@ -41,6 +41,7 @@ class ResourceServerConfiguration(private val barcodeUserDetailsService: UserDet
           "/swagger-ui.html",
           "/cjsm/directory/refresh", // Protected by the ingress - see Kube config in helm_deploy
           "/barcode-stats-report", // Protected by the ingress - see Kube config in helm_deploy
+          "/prisons",
         ).permitAll().anyRequest().authenticated()
       }.oauth2ResourceServer().jwt().jwtAuthenticationConverter(AuthAwareTokenConverter())
   }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,6 +26,9 @@ hmpps:
 prisoner:
   search:
     url: http://localhost:9092
+prison:
+  register:
+    url: https://prison-register-dev.hmpps.service.justice.gov.uk
 
 app:
   jwt:

--- a/src/main/resources/db/migration/V1_15__insert_supported_prisons.sql
+++ b/src/main/resources/db/migration/V1_15__insert_supported_prisons.sql
@@ -1,0 +1,5 @@
+INSERT INTO supported_prisons values ('SKI', true, 'INITIAL_LOAD', current_timestamp);
+INSERT INTO supported_prisons values ('LEI', true, 'INITIAL_LOAD', current_timestamp);
+INSERT INTO supported_prisons values ('SLI', true, 'INITIAL_LOAD', current_timestamp);
+INSERT INTO supported_prisons values ('HHI', true, 'INITIAL_LOAD', current_timestamp);
+INSERT INTO supported_prisons values ('RSI', true, 'INITIAL_LOAD', current_timestamp);

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/prisons/SupportedPrisonsResourceTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/sendlegalmailtoprisonsapi/prisons/SupportedPrisonsResourceTest.kt
@@ -18,26 +18,6 @@ class SupportedPrisonsResourceTest : IntegrationTest() {
   inner class GetSupportedPrison {
 
     @Test
-    fun `unauthorised without a valid token`() {
-      webTestClient.get()
-        .uri("/prisons")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus().isUnauthorized
-    }
-
-    @Test
-    fun `forbidden without a valid role`() {
-      webTestClient.get()
-        .uri("/prisons")
-        .accept(MediaType.APPLICATION_JSON)
-        .headers(setAuthorisation(user = "AUSER_GEN"))
-        .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.errorCode.code").isEqualTo(AuthenticationError.code)
-    }
-
-    @Test
     fun `returns supported prisons`() {
       supportedPrisonsRepository.save(aSupportedPrison(code = "CCC", active = true))
       supportedPrisonsRepository.save(aSupportedPrison(code = "BBB", active = false))


### PR DESCRIPTION
* the endpoint does not contain sensitive data and is publicly visible on the unprotected start page anyway
* also useLatestVersions
* add pilot prisons to the supported prisons table
* some missing config for prison register running locally