### PR TITLE
Give Circle CI access to dev and preprod for the smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
           path: artillery/test-run-report.json.html
 
   run_smoke_test:
+    circleci_ip_ranges: true
     executor: smoke-test
     parameters:
       env:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,6 +8,30 @@ generic-service:
     host: send-legal-mail-api-dev.prison.service.justice.gov.uk
     contextColour: green
 
+  allowlist:
+    # Circle CI allowed for smoke tests. IP ranges defined here: https://circleci.com/docs/2.0/ip-ranges#list-of-ip-address-ranges
+    circle-ci-1: "3.228.39.90"
+    circle-ci-2: "18.213.67.41"
+    circle-ci-3: "34.194.94.201"
+    circle-ci-4: "34.194.144.202"
+    circle-ci-5: "34.197.6.234"
+    circle-ci-6: "35.169.17.173"
+    circle-ci-7: "35.174.253.146"
+    circle-ci-8: "52.3.128.216"
+    circle-ci-9: "52.4.195.249"
+    circle-ci-10: "52.5.58.121"
+    circle-ci-11: "52.21.153.129"
+    circle-ci-12: "52.72.72.233"
+    circle-ci-13: "54.92.235.88"
+    circle-ci-14: "54.161.182.76"
+    circle-ci-15: "54.164.161.41"
+    circle-ci-16: "54.166.105.113"
+    circle-ci-17: "54.167.72.230"
+    circle-ci-18: "54.172.26.132"
+    circle-ci-19: "54.205.138.102"
+    circle-ci-20: "54.208.72.234"
+    circle-ci-21: "54.209.115.53"
+
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,6 +8,30 @@ generic-service:
     host: send-legal-mail-api-preprod.prison.service.justice.gov.uk
     contextColour: green
 
+  allowlist:
+    # Circle CI allowed for smoke tests. IP ranges defined here: https://circleci.com/docs/2.0/ip-ranges#list-of-ip-address-ranges
+    circle-ci-1: "3.228.39.90"
+    circle-ci-2: "18.213.67.41"
+    circle-ci-3: "34.194.94.201"
+    circle-ci-4: "34.194.144.202"
+    circle-ci-5: "34.197.6.234"
+    circle-ci-6: "35.169.17.173"
+    circle-ci-7: "35.174.253.146"
+    circle-ci-8: "52.3.128.216"
+    circle-ci-9: "52.4.195.249"
+    circle-ci-10: "52.5.58.121"
+    circle-ci-11: "52.21.153.129"
+    circle-ci-12: "52.72.72.233"
+    circle-ci-13: "54.92.235.88"
+    circle-ci-14: "54.161.182.76"
+    circle-ci-15: "54.164.161.41"
+    circle-ci-16: "54.166.105.113"
+    circle-ci-17: "54.167.72.230"
+    circle-ci-18: "54.172.26.132"
+    circle-ci-19: "54.205.138.102"
+    circle-ci-20: "54.208.72.234"
+    circle-ci-21: "54.209.115.53"
+
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
Similar change to https://github.com/ministryofjustice/send-legal-mail-to-prisons/pull/350. Since locking down `dev` and `preprod` environments, the Cypress smoke tests on CircleCI are failing as they can't access these.

This change adds CircleCI's IP ranges to the `allowlist` (`dev` and `preprod` only) so the smoke tests should be able to run.