### PR TITLE
Don't set a hard limit on pods memory

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
@@ -73,8 +73,6 @@ generic-service:
   resources:
     requests:
       memory: 512Mi
-    limits:
-      memory: 1Gi
 
 generic-prometheus-alerts:
   targetApplication: send-legal-mail-to-prisons-api


### PR DESCRIPTION
This caused a pod to be killed with an Out Of Memory error (https://mojdt.slack.com/archives/C03KYFY11S5/p1657749656902819). Apparently there is no need to limit the pods as the limit on the JVM is all we can really control.