### PR TITLE
Disable v0.47 ingress controller

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     v1_2_enabled: true
-    v0_47_enabled: true
+    v0_47_enabled: false
     host: app-hostname.local    # override per environment
     tlsSecretName: send-legal-mail-api-cert
     annotations:


### PR DESCRIPTION
Disable v0.47 ingress and keep only v1.2 enabled as mentioned here - 
https://github.com/ministryofjustice/hmpps-helm-charts/releases.