### PR TITLE
Minor dependency updates

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,12 @@ CVE-2022-38751
 # Suppression for snakeyaml 1.31 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-38752
+# Suppression for jackson databind 2.13.4 as no release for it yet
+#   Can be suppressed as UNWRAP_SINGLE_VALUE_ARRAYS is not enabled
+CVE-2022-42003
+# Suppression for jackson databind 2.13.3 as bundled with application insights
+#   Can be suppressed as don't parse untrusted json in application insights
+CVE-2022-42004
+# Suppression for apache common-text 1.9 as bundled with application insights
+#   can be suppressed for the time being as it will be fixed in next version of application insights
+CVE-2022-42889

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.5"
   id("org.unbroken-dome.test-sets") version "4.0.0"
   kotlin("plugin.spring") version "1.7.10"
   kotlin("plugin.jpa") version "1.7.10"
@@ -33,20 +33,20 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-webmvc-core:1.6.11")
 
   implementation("io.jsonwebtoken:jjwt:0.9.1")
-  implementation("io.github.microutils:kotlin-logging:2.1.23")
+  implementation("io.github.microutils:kotlin-logging:3.0.2")
 
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.296")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.319")
   implementation("org.apache.commons:commons-csv:1.9.0")
 
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql:42.5.0")
 
-  testImplementation("org.testcontainers:postgresql:1.17.3")
+  testImplementation("org.testcontainers:postgresql:1.17.4")
   testImplementation("it.ozimov:embedded-redis:0.7.3")
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")
   testImplementation("org.mockito:mockito-inline:4.8.0")
-  testImplementation("io.swagger.parser.v3:swagger-parser-v3:2.1.2")
-  testImplementation("org.testcontainers:localstack:1.17.3")
+  testImplementation("io.swagger.parser.v3:swagger-parser-v3:2.1.3")
+  testImplementation("org.testcontainers:localstack:1.17.4")
   testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
   testImplementation("org.springframework.security:spring-security-test")
 }


### PR DESCRIPTION
Update hmpps spring boot version to 4.5.5 as a fix for security failures and other minor dependency updates.