### PR TITLE
Upgrade dependencies as a fix for security failures.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -16,6 +16,9 @@ CVE-2022-38751
 CVE-2022-38752
 # Suppression for snakeyaml 1.33 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
+CVE-2022-1471
+# Suppression for snakeyaml 1.33 vulnerability as not fixed yet
+#   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-41854
 # Suppression for jackson databind 2.13.4 as no release for it yet
 #   Can be suppressed as UNWRAP_SINGLE_VALUE_ARRAYS is not enabled
@@ -26,3 +29,6 @@ CVE-2022-42004
 # Suppression for apache common-text 1.9 as bundled with application insights
 #   can be suppressed for the time being as it will be fixed in next version of application insights
 CVE-2022-42889
+# Suppression for h2 2.1.214 password on command line vulnerability
+#   can be suppressed as we only run h2 locally and not on build environments
+CVE-2022-45868

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.6.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.7.1"
   id("org.unbroken-dome.test-sets") version "4.0.0"
   kotlin("plugin.spring") version "1.7.20"
   kotlin("plugin.jpa") version "1.7.20"
@@ -35,7 +35,7 @@ dependencies {
   implementation("io.jsonwebtoken:jjwt:0.9.1")
   implementation("io.github.microutils:kotlin-logging:3.0.4")
 
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.347")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.351")
   implementation("org.apache.commons:commons-csv:1.9.0")
 
   runtimeOnly("org.flywaydb:flyway-core")


### PR DESCRIPTION
Upgrade hmpps.gradle-spring-boot dependency as a fix for security failures.