### PR TITLE
Upgrade hmpps.gradle-spring-boot dependency 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.1"
   id("org.unbroken-dome.test-sets") version "4.0.0"
-  kotlin("plugin.spring") version "1.7.20"
-  kotlin("plugin.jpa") version "1.7.20"
+  kotlin("plugin.spring") version "1.8.0"
+  kotlin("plugin.jpa") version "1.8.0"
   id("jacoco")
   id("org.openapi.generator") version "6.0.1"
 }
@@ -35,7 +35,7 @@ dependencies {
   implementation("io.jsonwebtoken:jjwt:0.9.1")
   implementation("io.github.microutils:kotlin-logging:3.0.4")
 
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.372")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.382")
   implementation("org.apache.commons:commons-csv:1.9.0")
 
   runtimeOnly("org.flywaydb:flyway-core")
@@ -44,8 +44,8 @@ dependencies {
   testImplementation("org.testcontainers:postgresql:1.17.6")
   testImplementation("it.ozimov:embedded-redis:0.7.3")
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")
-  testImplementation("org.mockito:mockito-inline:4.10.0")
-  testImplementation("io.swagger.parser.v3:swagger-parser-v3:2.1.8")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+  testImplementation("io.swagger.parser.v3:swagger-parser-v3:2.1.10")
   testImplementation("org.testcontainers:localstack:1.17.6")
   testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
   testImplementation("org.springframework.security:spring-security-test")


### PR DESCRIPTION
Upgrade hmpps.gradle-spring-boot dependency as a fix for security failures and other minor version updates.