### PR TITLE
Silence dev alerts when not business hours

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -52,3 +52,4 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: send-legal-mail-alerts
+  businessHoursOnly: true


### PR DESCRIPTION
Silence alerts from the dev environment outside of business hours.

Since the dev database was scheduled to turn off overnight, we get repeated alert manager notifications from the API (https://github.com/ministryofjustice/cloud-platform-environments/blob/12938dea078e35a7689bd395086e6d61d049af24/namespaces/live.cloud-platform.service.justice.gov.uk/send-legal-mail-to-prisons-dev/resources/rds.tf#L11)

This applies the `businessHoursOnly` rule to alerts from the dev environment (documented here: https://github.com/ministryofjustice/hmpps-helm-charts/blob/4ce3afdf951a6e6b433a67cd39336a4a91901704/charts/generic-prometheus-alerts/values.yaml#L101-L102)