### PR TITLE
Reschedule dev crons to business hours

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons-api/templates/barcode-stats-report-cronjob.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons-api/templates/barcode-stats-report-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: send-legal-mail-to-prisons-api-barcode-stats-report
 spec:
-  schedule: "5 6 * * *"
+  schedule: "{{ .Values.cron.barcodeStatsReportSchedule }}"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 6000

--- a/helm_deploy/send-legal-mail-to-prisons-api/templates/cjsm-directory-cronjob.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons-api/templates/cjsm-directory-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: send-legal-mail-to-prisons-api-cjsm-directory
 spec:
-  schedule: "15 3 * * *"
+  schedule: "{{ .Values.cron.cjsmDirectorySchedule }}"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 6000

--- a/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons-api/values.yaml
@@ -68,3 +68,8 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: send-legal-mail-to-prisons-api
+
+cron:
+  barcodeStatsReportSchedule: "5 6 * * *"
+  cjsmDirectorySchedule: "15 3 * * *"
+

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -33,3 +33,8 @@ generic-service:
 generic-prometheus-alerts:
   alertSeverity: send-legal-mail-alerts
   businessHoursOnly: true
+
+cron:
+  barcodeStatsReportSchedule: "5 8 * * 1-5"
+  cjsmDirectorySchedule: "15 8 * * 1-5"
+


### PR DESCRIPTION
Hopefully avoid failing cron errors because the dev database is shut down overnight and at weekends.